### PR TITLE
Add CV pages rendered from JSON with PDF export (EN/PT)

### DIFF
--- a/app/body-layout.tsx
+++ b/app/body-layout.tsx
@@ -11,7 +11,7 @@ export function BodyLayout({ children }: { children: React.ReactNode }) {
   const { theme } = useThemeContext();
 
   return (
-    <body className={`flex flex-col min-h-[100vh] container max-w-6xl ${inter.className} ${theme}`}>
+    <body className={`flex flex-col min-h-[100vh] container max-w-6xl print:max-w-none print:p-0 ${inter.className} ${theme}`}>
       <Header />
       <main className="flex-grow">{children}</main>
       <Footer />

--- a/app/cv/[lang]/page.tsx
+++ b/app/cv/[lang]/page.tsx
@@ -1,0 +1,26 @@
+import { Metadata } from "next";
+import { notFound } from "next/navigation";
+
+import CvView from "@/components/cv/cv-view";
+import { LANGS, cv, isLang } from "@/lib/cv";
+
+export const dynamicParams = false;
+
+export function generateStaticParams() {
+  return LANGS.map((lang) => ({ lang }));
+}
+
+export function generateMetadata({ params }: { params: { lang: string } }): Metadata {
+  const description = isLang(params.lang) && params.lang === "pt"
+    ? `Currículo de ${cv.basics.name}`
+    : `Resume of ${cv.basics.name}`;
+  return {
+    title: `CV | ${cv.basics.name}`,
+    description,
+  };
+}
+
+export default function CvPage({ params }: { params: { lang: string } }) {
+  if (!isLang(params.lang)) notFound();
+  return <CvView lang={params.lang} />;
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -95,7 +95,30 @@
     margin: 12mm;
   }
 
+  html {
+    color-scheme: light;
+  }
+
   body {
     background: white !important;
+  }
+
+  /* The CV always exports in light mode, whatever the on-screen theme */
+  body, body.dark {
+    --background: 0 0% 100%;
+    --foreground: 240 10% 3.9%;
+    --card: 0 0% 100%;
+    --card-foreground: 240 10% 3.9%;
+    --secondary: 240 4.8% 95.9%;
+    --secondary-foreground: 240 5.9% 10%;
+    --muted: 240 4.8% 95.9%;
+    --muted-foreground: 240 3.8% 46.1%;
+    --border: 240 5.9% 90%;
+  }
+
+  /* Keep the grey section banners visible on paper */
+  * {
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
   }
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -87,3 +87,15 @@
     @apply bg-background text-foreground;
   }
 }
+
+/* Print setup for the CV pages: white paper, no site chrome */
+@media print {
+  @page {
+    size: A4;
+    margin: 12mm;
+  }
+
+  body {
+    background: white !important;
+  }
+}

--- a/components/cv/cv-view.tsx
+++ b/components/cv/cv-view.tsx
@@ -20,7 +20,7 @@ function getProfileIcon(network: string) {
 
 function Banner({ children }: { children: React.ReactNode }) {
   return (
-    <h2 className="bg-zinc-100 px-4 py-2 text-sm font-bold uppercase tracking-widest text-zinc-900 break-inside-avoid">
+    <h2 className="bg-secondary px-4 py-2 text-sm font-bold uppercase tracking-widest text-secondary-foreground break-inside-avoid">
       {children}
     </h2>
   );
@@ -29,7 +29,7 @@ function Banner({ children }: { children: React.ReactNode }) {
 function Entry({ aside, children }: { aside?: React.ReactNode, children: React.ReactNode }) {
   return (
     <div className="grid gap-2 sm:grid-cols-[160px_1fr] sm:gap-x-6 break-inside-avoid">
-      <div className="text-sm text-zinc-500">{aside}</div>
+      <div className="text-sm text-muted-foreground">{aside}</div>
       <div>{children}</div>
     </div>
   );
@@ -56,7 +56,7 @@ export default function CvView({ lang }: { lang: Lang }) {
         </Button>
       </div>
 
-      <article className="flex flex-col gap-6 rounded-md bg-white p-8 text-zinc-900 shadow-lg sm:p-12 print:gap-5 print:rounded-none print:p-0 print:shadow-none">
+      <article className="flex flex-col gap-6 rounded-md border bg-card p-8 text-card-foreground shadow-lg sm:p-12 print:gap-5 print:rounded-none print:border-none print:p-0 print:shadow-none">
 
         {/* Header: name on the left, contacts on the right */}
         <header className="flex flex-wrap justify-between gap-6">
@@ -64,24 +64,24 @@ export default function CvView({ lang }: { lang: Lang }) {
             <h1 className="max-w-72 text-4xl font-extrabold uppercase leading-none tracking-wide sm:text-5xl">
               {cv.basics.name}
             </h1>
-            <p className="mt-3 text-zinc-500">{loc(cv.basics.label)}</p>
+            <p className="mt-3 text-muted-foreground">{loc(cv.basics.label)}</p>
           </div>
           <ul className="flex flex-col gap-2 text-sm">
             <li className="flex items-center gap-2">
-              <Phone size={14} className="shrink-0 text-zinc-500" />{cv.basics.phone}
+              <Phone size={14} className="shrink-0 text-muted-foreground" />{cv.basics.phone}
             </li>
             <li className="flex items-center gap-2">
-              <Mail size={14} className="shrink-0 text-zinc-500" />
+              <Mail size={14} className="shrink-0 text-muted-foreground" />
               <a href={`mailto:${cv.basics.email}`}>{cv.basics.email}</a>
             </li>
             <li className="flex items-center gap-2">
-              <MapPin size={14} className="shrink-0 text-zinc-500" />{loc(cv.basics.location)}
+              <MapPin size={14} className="shrink-0 text-muted-foreground" />{loc(cv.basics.location)}
             </li>
             {cv.basics.profiles.map((profile) => {
               const Icon = getProfileIcon(profile.network);
               return (
                 <li key={profile.network} className="flex items-center gap-2">
-                  <Icon size={14} className="shrink-0 text-zinc-500" />
+                  <Icon size={14} className="shrink-0 text-muted-foreground" />
                   <a href={profile.url} target="_blank" rel="noreferrer">{profile.label}</a>
                 </li>
               );
@@ -92,7 +92,7 @@ export default function CvView({ lang }: { lang: Lang }) {
         {cv.profile && (
           <section className="flex flex-col gap-3">
             <Banner>{labels.profile[lang]}</Banner>
-            <p className="text-sm leading-relaxed text-zinc-700">{loc(cv.profile)}</p>
+            <p className="text-sm leading-relaxed text-foreground/80">{loc(cv.profile)}</p>
           </section>
         )}
 
@@ -105,21 +105,21 @@ export default function CvView({ lang }: { lang: Lang }) {
                 aside={
                   <>
                     {job.url
-                      ? <a href={job.url} target="_blank" rel="noreferrer" className="block font-semibold text-zinc-700">{job.company}</a>
-                      : <span className="block font-semibold text-zinc-700">{job.company}</span>}
+                      ? <a href={job.url} target="_blank" rel="noreferrer" className="block font-semibold text-foreground/90">{job.company}</a>
+                      : <span className="block font-semibold text-foreground/90">{job.company}</span>}
                     <span className="tabular-nums">{formatDateRange(job.startDate, job.endDate, lang)}</span>
                   </>
                 }
               >
                 <h3 className="mb-1.5 text-base font-bold">{loc(job.position)}</h3>
-                <ul className="flex list-disc flex-col gap-1 pl-4 text-sm text-zinc-700">
+                <ul className="flex list-disc flex-col gap-1 pl-4 text-sm text-foreground/80">
                   {job.highlights.map((highlight, index) => (
                     <li key={index}>{loc(highlight)}</li>
                   ))}
                 </ul>
                 {job.technologies.length > 0 && (
-                  <p className="mt-1.5 text-xs text-zinc-500">
-                    <span className="font-semibold text-zinc-600">{labels.technologies[lang]}:</span>{" "}
+                  <p className="mt-1.5 text-xs text-muted-foreground">
+                    <span className="font-semibold text-foreground/80">{labels.technologies[lang]}:</span>{" "}
                     {job.technologies.join(" · ")}
                   </p>
                 )}
@@ -136,7 +136,7 @@ export default function CvView({ lang }: { lang: Lang }) {
                 key={index}
                 aside={
                   <>
-                    {education.institution && <span className="block font-semibold text-zinc-700">{education.institution}</span>}
+                    {education.institution && <span className="block font-semibold text-foreground/90">{education.institution}</span>}
                     <span className="tabular-nums">{formatDateRange(education.startDate, education.endDate, lang)}</span>
                   </>
                 }
@@ -151,7 +151,7 @@ export default function CvView({ lang }: { lang: Lang }) {
           <section className="flex flex-col gap-3">
             <Banner>{labels.courses[lang]}</Banner>
             <Entry>
-              <ul className="flex list-disc flex-col gap-1 pl-4 text-sm text-zinc-700">
+              <ul className="flex list-disc flex-col gap-1 pl-4 text-sm text-foreground/80">
                 {cv.courses.map((course, index) => (
                   <li key={index}>{loc(course)}</li>
                 ))}
@@ -162,14 +162,14 @@ export default function CvView({ lang }: { lang: Lang }) {
 
         {cv.skills.length > 0 && (
           <section className="grid gap-2 sm:grid-cols-[160px_1fr] sm:gap-x-6 break-inside-avoid">
-            <h2 className="self-start bg-zinc-100 px-4 py-2 text-sm font-bold uppercase tracking-widest text-zinc-900">
+            <h2 className="self-start bg-secondary px-4 py-2 text-sm font-bold uppercase tracking-widest text-secondary-foreground">
               {labels.skills[lang]}
             </h2>
             <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
               {cv.skills.map((group, index) => (
                 <div key={index}>
                   <h3 className="mb-1.5 text-sm font-bold">{loc(group.category)}</h3>
-                  <ul className="flex flex-col gap-1 text-sm text-zinc-500">
+                  <ul className="flex flex-col gap-1 text-sm text-muted-foreground">
                     {group.items.map((item) => (
                       <li key={item}>{item}</li>
                     ))}
@@ -182,14 +182,14 @@ export default function CvView({ lang }: { lang: Lang }) {
 
         {cv.languages.length > 0 && (
           <section className="grid gap-2 sm:grid-cols-[160px_1fr] sm:gap-x-6 break-inside-avoid">
-            <h2 className="self-start bg-zinc-100 px-4 py-2 text-sm font-bold uppercase tracking-widest text-zinc-900">
+            <h2 className="self-start bg-secondary px-4 py-2 text-sm font-bold uppercase tracking-widest text-secondary-foreground">
               {labels.languages[lang]}
             </h2>
             <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
               {cv.languages.map((language, index) => (
                 <div key={index}>
                   <h3 className="mb-1.5 text-sm font-bold">{loc(language.name)}</h3>
-                  <p className="text-sm text-zinc-500">{loc(language.level)}</p>
+                  <p className="text-sm text-muted-foreground">{loc(language.level)}</p>
                 </div>
               ))}
             </div>

--- a/components/cv/cv-view.tsx
+++ b/components/cv/cv-view.tsx
@@ -1,0 +1,202 @@
+"use client"
+
+import Link from "next/link";
+import { Download, Github, Globe, Linkedin, Mail, MapPin, Phone } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import getIcon from "@/components/svg/utils";
+import { Lang, Localized, cv, formatDateRange, labels, t } from "@/lib/cv";
+
+function getProfileIcon(network: string) {
+  switch (network) {
+    case "linkedin":
+      return Linkedin;
+    case "github":
+      return Github;
+    default:
+      return Globe;
+  }
+}
+
+function Banner({ children }: { children: React.ReactNode }) {
+  return (
+    <h2 className="bg-zinc-100 px-4 py-2 text-sm font-bold uppercase tracking-widest text-zinc-900 break-inside-avoid">
+      {children}
+    </h2>
+  );
+}
+
+function Entry({ aside, children }: { aside?: React.ReactNode, children: React.ReactNode }) {
+  return (
+    <div className="grid gap-2 sm:grid-cols-[160px_1fr] sm:gap-x-6 break-inside-avoid">
+      <div className="text-sm text-zinc-500">{aside}</div>
+      <div>{children}</div>
+    </div>
+  );
+}
+
+export default function CvView({ lang }: { lang: Lang }) {
+  const otherLang: Lang = lang === "en" ? "pt" : "en";
+  const OtherFlag = getIcon(otherLang);
+  const loc = (value: Localized) => t(value, lang);
+
+  return (
+    <div className="mx-auto my-10 flex w-full max-w-3xl flex-col gap-4 print:my-0 print:max-w-none">
+
+      <div className="flex items-center justify-between gap-4 print:hidden">
+        <Button variant="outline" asChild>
+          <Link href={`/cv/${otherLang}`} className="flex items-center gap-2">
+            <OtherFlag className="text-xl" />
+            {labels.otherLanguage[lang]}
+          </Link>
+        </Button>
+        <Button onClick={() => window.print()} className="flex items-center gap-2">
+          <Download size={16} />
+          {labels.exportPdf[lang]}
+        </Button>
+      </div>
+
+      <article className="flex flex-col gap-6 rounded-md bg-white p-8 text-zinc-900 shadow-lg sm:p-12 print:gap-5 print:rounded-none print:p-0 print:shadow-none">
+
+        {/* Header: name on the left, contacts on the right */}
+        <header className="flex flex-wrap justify-between gap-6">
+          <div>
+            <h1 className="max-w-72 text-4xl font-extrabold uppercase leading-none tracking-wide sm:text-5xl">
+              {cv.basics.name}
+            </h1>
+            <p className="mt-3 text-zinc-500">{loc(cv.basics.label)}</p>
+          </div>
+          <ul className="flex flex-col gap-2 text-sm">
+            <li className="flex items-center gap-2">
+              <Phone size={14} className="shrink-0 text-zinc-500" />{cv.basics.phone}
+            </li>
+            <li className="flex items-center gap-2">
+              <Mail size={14} className="shrink-0 text-zinc-500" />
+              <a href={`mailto:${cv.basics.email}`}>{cv.basics.email}</a>
+            </li>
+            <li className="flex items-center gap-2">
+              <MapPin size={14} className="shrink-0 text-zinc-500" />{loc(cv.basics.location)}
+            </li>
+            {cv.basics.profiles.map((profile) => {
+              const Icon = getProfileIcon(profile.network);
+              return (
+                <li key={profile.network} className="flex items-center gap-2">
+                  <Icon size={14} className="shrink-0 text-zinc-500" />
+                  <a href={profile.url} target="_blank" rel="noreferrer">{profile.label}</a>
+                </li>
+              );
+            })}
+          </ul>
+        </header>
+
+        {cv.profile && (
+          <section className="flex flex-col gap-3">
+            <Banner>{labels.profile[lang]}</Banner>
+            <p className="text-sm leading-relaxed text-zinc-700">{loc(cv.profile)}</p>
+          </section>
+        )}
+
+        {cv.work.length > 0 && (
+          <section className="flex flex-col gap-4">
+            <Banner>{labels.employmentHistory[lang]}</Banner>
+            {cv.work.map((job) => (
+              <Entry
+                key={`${job.company}-${job.startDate}`}
+                aside={
+                  <>
+                    {job.url
+                      ? <a href={job.url} target="_blank" rel="noreferrer" className="block font-semibold text-zinc-700">{job.company}</a>
+                      : <span className="block font-semibold text-zinc-700">{job.company}</span>}
+                    <span className="tabular-nums">{formatDateRange(job.startDate, job.endDate, lang)}</span>
+                  </>
+                }
+              >
+                <h3 className="mb-1.5 text-base font-bold">{loc(job.position)}</h3>
+                <ul className="flex list-disc flex-col gap-1 pl-4 text-sm text-zinc-700">
+                  {job.highlights.map((highlight, index) => (
+                    <li key={index}>{loc(highlight)}</li>
+                  ))}
+                </ul>
+                {job.technologies.length > 0 && (
+                  <p className="mt-1.5 text-xs text-zinc-500">
+                    <span className="font-semibold text-zinc-600">{labels.technologies[lang]}:</span>{" "}
+                    {job.technologies.join(" · ")}
+                  </p>
+                )}
+              </Entry>
+            ))}
+          </section>
+        )}
+
+        {cv.education.length > 0 && (
+          <section className="flex flex-col gap-3">
+            <Banner>{labels.education[lang]}</Banner>
+            {cv.education.map((education, index) => (
+              <Entry
+                key={index}
+                aside={
+                  <>
+                    {education.institution && <span className="block font-semibold text-zinc-700">{education.institution}</span>}
+                    <span className="tabular-nums">{formatDateRange(education.startDate, education.endDate, lang)}</span>
+                  </>
+                }
+              >
+                <h3 className="text-base font-bold">{loc(education.degree)}</h3>
+              </Entry>
+            ))}
+          </section>
+        )}
+
+        {cv.courses.length > 0 && (
+          <section className="flex flex-col gap-3">
+            <Banner>{labels.courses[lang]}</Banner>
+            <Entry>
+              <ul className="flex list-disc flex-col gap-1 pl-4 text-sm text-zinc-700">
+                {cv.courses.map((course, index) => (
+                  <li key={index}>{loc(course)}</li>
+                ))}
+              </ul>
+            </Entry>
+          </section>
+        )}
+
+        {cv.skills.length > 0 && (
+          <section className="grid gap-2 sm:grid-cols-[160px_1fr] sm:gap-x-6 break-inside-avoid">
+            <h2 className="self-start bg-zinc-100 px-4 py-2 text-sm font-bold uppercase tracking-widest text-zinc-900">
+              {labels.skills[lang]}
+            </h2>
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+              {cv.skills.map((group, index) => (
+                <div key={index}>
+                  <h3 className="mb-1.5 text-sm font-bold">{loc(group.category)}</h3>
+                  <ul className="flex flex-col gap-1 text-sm text-zinc-500">
+                    {group.items.map((item) => (
+                      <li key={item}>{item}</li>
+                    ))}
+                  </ul>
+                </div>
+              ))}
+            </div>
+          </section>
+        )}
+
+        {cv.languages.length > 0 && (
+          <section className="grid gap-2 sm:grid-cols-[160px_1fr] sm:gap-x-6 break-inside-avoid">
+            <h2 className="self-start bg-zinc-100 px-4 py-2 text-sm font-bold uppercase tracking-widest text-zinc-900">
+              {labels.languages[lang]}
+            </h2>
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+              {cv.languages.map((language, index) => (
+                <div key={index}>
+                  <h3 className="mb-1.5 text-sm font-bold">{loc(language.name)}</h3>
+                  <p className="text-sm text-zinc-500">{loc(language.level)}</p>
+                </div>
+              ))}
+            </div>
+          </section>
+        )}
+
+      </article>
+    </div>
+  );
+}

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -5,7 +5,7 @@ import { data } from "@/lib/utils";
 
 export default function Footer() {
   return (
-    <footer id="footer" className="py-6 lg:py-10">
+    <footer id="footer" className="py-6 lg:py-10 print:hidden">
       <hr className="my-5"/>
       <div className="flex flex-col sm:flex-row justify-between gap-8 items-center text-muted-foreground">
         <ul className="sm:w-28 flex flex-col items-center gap-2 px-4">

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -15,7 +15,7 @@ export default function Header(){
   ];
 
   return (
-    <header className="py-6 lg:py-10">
+    <header className="py-6 lg:py-10 print:hidden">
       <div className="flex gap-4 flex-row justify-between items-center md:gap-8">
         <Link className="hidden lg:inline-block" href="#">
           <LogoIcon className="dark:text-zinc-800 text-zinc-200 text-4xl" />

--- a/components/resume.tsx
+++ b/components/resume.tsx
@@ -15,7 +15,7 @@ export default function Resume() {
             return (
               <li key={index}>
                 <Button className="py-7" variant="ghost">
-                  <Link href={resume.link} target="_blank">
+                  <Link href={resume.link}>
                     <Icon className="text-4xl" />
                   </Link>
                 </Button>

--- a/lib/cv.json
+++ b/lib/cv.json
@@ -1,0 +1,202 @@
+{
+  "basics": {
+    "name": "Igor Souza",
+    "label": {
+      "en": "Software Engineer",
+      "pt": "Engenheiro de Software"
+    },
+    "email": "igormcsouza@gmail.com",
+    "phone": "(+55) 85 99839-2799",
+    "location": {
+      "en": "Eusébio/Ceará, Brazil",
+      "pt": "Eusébio/Ceará, Brasil"
+    },
+    "profiles": [
+      {
+        "network": "linkedin",
+        "label": "linkedin.com/in/igormcsouza",
+        "url": "https://www.linkedin.com/in/igormcsouza/"
+      },
+      {
+        "network": "github",
+        "label": "github.com/igormcsouza",
+        "url": "https://github.com/igormcsouza"
+      }
+    ]
+  },
+  "profile": {
+    "en": "Experienced in machine learning (Python, TensorFlow, Torch), computer vision, backend development (Flask, Django and FastAPI), Docker, Kubernetes and cloud platforms (Azure, AWS, GCP). Skilled in system administration and infrastructure management (Linux, Docker, Kubernetes, RabbitMQ). Proficient in front-end frameworks (Vue, React) and skilled in system optimization and troubleshooting.",
+    "pt": "Experiente em machine learning (Python, TensorFlow, Torch), visão computacional, desenvolvimento backend (Flask, Django e FastAPI), Docker, Kubernetes e plataformas de nuvem (Azure, AWS, GCP). Habilidoso em administração de sistemas e gerenciamento de infraestrutura (Linux, Docker, Kubernetes, RabbitMQ). Proficiente em frameworks front-end (Vue, React) e em otimização e resolução de problemas de sistemas."
+  },
+  "work": [
+    {
+      "company": "DataArt",
+      "url": "https://www.dataart.com/",
+      "position": {
+        "en": "Python Engineer Middle",
+        "pt": "Engenheiro Python Pleno"
+      },
+      "startDate": "2022-05",
+      "endDate": null,
+      "highlights": [
+        {
+          "en": "Managed an upgrade project involving JavaScript, Java, Python and Perl components.",
+          "pt": "Gerenciei um projeto de atualização envolvendo componentes em JavaScript, Java, Python e Perl."
+        },
+        {
+          "en": "Played a key role in OS upgrades and server communication optimizations.",
+          "pt": "Tive papel fundamental em atualizações de sistema operacional e otimizações de comunicação entre servidores."
+        },
+        {
+          "en": "Deepened expertise in Python, Linux system administration and networking.",
+          "pt": "Aprofundei conhecimentos em Python, administração de sistemas Linux e redes."
+        }
+      ],
+      "technologies": ["Python", "Linux", "Networking", "Java", "Perl"]
+    },
+    {
+      "company": "Liber Capital",
+      "url": "https://libercapital.com.br/",
+      "position": {
+        "en": "Python Engineer Middle",
+        "pt": "Engenheiro Python Pleno"
+      },
+      "startDate": "2021-12",
+      "endDate": "2022-05",
+      "highlights": [
+        {
+          "en": "Provided backend support in Python (Flask) for financial systems.",
+          "pt": "Prestei suporte backend em Python (Flask) para sistemas financeiros."
+        },
+        {
+          "en": "Worked on infrastructure using Docker, Kubernetes, RabbitMQ and GCP.",
+          "pt": "Trabalhei na infraestrutura utilizando Docker, Kubernetes, RabbitMQ e GCP."
+        },
+        {
+          "en": "Resolved communication bugs between Django and Ruby components, gaining expertise in system administration and troubleshooting.",
+          "pt": "Resolvi bugs de comunicação entre componentes Django e Ruby, ganhando experiência em administração de sistemas e resolução de problemas."
+        }
+      ],
+      "technologies": ["Python", "Flask", "Docker", "Kubernetes", "RabbitMQ", "GCP"]
+    },
+    {
+      "company": "Dell Lead",
+      "url": "https://lead.dell.com/",
+      "position": {
+        "en": "Python Engineer Junior",
+        "pt": "Engenheiro Python Júnior"
+      },
+      "startDate": "2020-04",
+      "endDate": "2021-12",
+      "highlights": [
+        {
+          "en": "Led projects in computer vision for accessibility, including models for image-to-text conversion.",
+          "pt": "Liderei projetos de visão computacional para acessibilidade, incluindo modelos de conversão de imagem em texto."
+        },
+        {
+          "en": "Developed a Telegram bot for contextual image responses.",
+          "pt": "Desenvolvi um bot de Telegram para respostas contextuais baseadas em imagens."
+        },
+        {
+          "en": "Utilized TensorFlow, Torch, Vue, Streamlit, Flask, React, Docker, Azure and AWS for development and deployment.",
+          "pt": "Utilizei TensorFlow, Torch, Vue, Streamlit, Flask, React, Docker, Azure e AWS para desenvolvimento e implantação."
+        }
+      ],
+      "technologies": ["TensorFlow", "Torch", "Vue", "React", "Streamlit", "Docker", "Azure", "AWS"]
+    },
+    {
+      "company": "Deeper Systems",
+      "url": "https://www.deepersystems.com/",
+      "position": {
+        "en": "Python Engineer Junior",
+        "pt": "Engenheiro Python Júnior"
+      },
+      "startDate": "2019-09",
+      "endDate": "2020-04",
+      "highlights": [
+        {
+          "en": "Developed machine learning models, especially in computer vision, for various projects.",
+          "pt": "Desenvolvi modelos de machine learning, especialmente em visão computacional, para diversos projetos."
+        },
+        {
+          "en": "Integrated models into Flask APIs using Python, TensorFlow, Torch, OpenCV, OpenPose and Selenium.",
+          "pt": "Integrei modelos em APIs Flask utilizando Python, TensorFlow, Torch, OpenCV, OpenPose e Selenium."
+        },
+        {
+          "en": "Proficient use of Docker, Linux and SSH for development and deployment.",
+          "pt": "Uso proficiente de Docker, Linux e SSH para desenvolvimento e implantação."
+        }
+      ],
+      "technologies": ["Python", "TensorFlow", "OpenCV", "Flask", "Docker", "Linux"]
+    }
+  ],
+  "education": [
+    {
+      "institution": "",
+      "degree": {
+        "en": "Bachelor in Software Engineering",
+        "pt": "Bacharelado em Engenharia de Software"
+      },
+      "startDate": null,
+      "endDate": null
+    }
+  ],
+  "courses": [
+    "NLP - Natural Language Processing",
+    "REST Api com Python e Flask",
+    "Docker and Kubernetes: The Complete Guide",
+    "Artificial Intelligence: Reinforcement Learning in Python"
+  ],
+  "skills": [
+    {
+      "category": {
+        "en": "Machine Learning",
+        "pt": "Machine Learning"
+      },
+      "items": ["Scikit-learn", "TensorFlow", "Torch", "LLMs", "Langchain", "Computer Vision"]
+    },
+    {
+      "category": {
+        "en": "Backend",
+        "pt": "Backend"
+      },
+      "items": ["Python", "Flask", "Django", "FastAPI", "Next.js"]
+    },
+    {
+      "category": {
+        "en": "Infrastructure",
+        "pt": "Infraestrutura"
+      },
+      "items": ["Docker", "Kubernetes", "AMQP", "Linux", "Azure", "AWS", "GCP"]
+    },
+    {
+      "category": {
+        "en": "Frontend",
+        "pt": "Frontend"
+      },
+      "items": ["React", "Vue", "TailwindCSS"]
+    }
+  ],
+  "languages": [
+    {
+      "name": {
+        "en": "Portuguese",
+        "pt": "Português"
+      },
+      "level": {
+        "en": "Native",
+        "pt": "Nativo"
+      }
+    },
+    {
+      "name": {
+        "en": "English",
+        "pt": "Inglês"
+      },
+      "level": {
+        "en": "Fluent",
+        "pt": "Fluente"
+      }
+    }
+  ]
+}

--- a/lib/cv.ts
+++ b/lib/cv.ts
@@ -1,0 +1,107 @@
+import cvData from "./cv.json";
+
+export const LANGS = ["en", "pt"] as const;
+export type Lang = (typeof LANGS)[number];
+
+/**
+ * A string that may or may not carry a translation. Plain strings are used
+ * for content that needs no translation (names, technologies, course titles).
+ */
+export type Localized = string | { en: string; pt: string };
+
+export interface CvProfileLink {
+  network: string;
+  label: string;
+  url: string;
+}
+
+export interface CvBasics {
+  name: string;
+  label: Localized;
+  email: string;
+  phone: string;
+  location: Localized;
+  profiles: CvProfileLink[];
+}
+
+export interface CvWork {
+  company: string;
+  url?: string;
+  position: Localized;
+  startDate: string | null;
+  endDate: string | null;
+  highlights: Localized[];
+  technologies: string[];
+}
+
+export interface CvEducation {
+  institution: string;
+  degree: Localized;
+  startDate: string | null;
+  endDate: string | null;
+}
+
+export interface CvSkillGroup {
+  category: Localized;
+  items: string[];
+}
+
+export interface CvLanguage {
+  name: Localized;
+  level: Localized;
+}
+
+export interface Cv {
+  basics: CvBasics;
+  profile: Localized;
+  work: CvWork[];
+  education: CvEducation[];
+  courses: Localized[];
+  skills: CvSkillGroup[];
+  languages: CvLanguage[];
+}
+
+export const cv: Cv = cvData;
+
+export function isLang(value: string): value is Lang {
+  return (LANGS as readonly string[]).includes(value);
+}
+
+/** Resolve a Localized value for the given language. */
+export function t(value: Localized, lang: Lang): string {
+  return typeof value === "string" ? value : value[lang];
+}
+
+/** UI labels for the CV template, per language. */
+export const labels = {
+  profile: { en: "Profile", pt: "Perfil" },
+  employmentHistory: { en: "Employment History", pt: "Histórico Profissional" },
+  education: { en: "Education", pt: "Formação Acadêmica" },
+  courses: { en: "Relevant Courses", pt: "Cursos Relevantes" },
+  skills: { en: "Skills", pt: "Habilidades" },
+  languages: { en: "Languages", pt: "Idiomas" },
+  technologies: { en: "Tech", pt: "Tecnologias" },
+  exportPdf: { en: "Export PDF", pt: "Exportar PDF" },
+  otherLanguage: { en: "Ver em Português", pt: "View in English" },
+  present: { en: "present", pt: "atual" },
+} satisfies Record<string, { en: string; pt: string }>;
+
+const MONTHS: Record<Lang, string[]> = {
+  en: ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"],
+  pt: ["Janeiro", "Fevereiro", "Março", "Abril", "Maio", "Junho", "Julho", "Agosto", "Setembro", "Outubro", "Novembro", "Dezembro"],
+};
+
+/** Format a "YYYY-MM" (or "YYYY") date as e.g. "May 2022" / "Maio 2022". */
+export function formatDate(date: string, lang: Lang): string {
+  const [year, month] = date.split("-");
+  if (!month) return year;
+  return `${MONTHS[lang][Number(month) - 1]} ${year}`;
+}
+
+/** Format a period as e.g. "May 2022 – present" / "Maio 2022 – atual". */
+export function formatDateRange(start: string | null, end: string | null, lang: Lang): string {
+  if (!start && !end) return "";
+  const from = start ? formatDate(start, lang) : "";
+  const to = end ? formatDate(end, lang) : labels.present[lang];
+  return from ? `${from} – ${to}` : to;
+}

--- a/lib/data.json
+++ b/lib/data.json
@@ -74,11 +74,11 @@
     "resume": [
       {
         "lang": "en",
-        "link": "https://igormcsouza.notion.site/Online-Resume-1f64209285184377b86a49baa9998edf"
+        "link": "/cv/en"
       },
       {
         "lang": "pt",
-        "link": "https://igormcsouza.notion.site/Online-Resume-1f64209285184377b86a49baa9998edf"
+        "link": "/cv/pt"
       }
     ],
     "work": {


### PR DESCRIPTION
- New lib/cv.json holding all resume data; localizable fields carry
  both English and Portuguese, plain strings stay untranslated
- lib/cv.ts with types, t() localization helper, section labels and
  locale-aware date range formatting
- Static /cv/en and /cv/pt routes rendering the CV template with a
  link to the other language and an Export PDF button (window.print)
- Print styles: A4 page setup, site header/footer hidden, sheet
  rendered as plain paper
- Homepage resume flags now deep-link to the internal CV pages
  instead of the external Notion document

Closes #58

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VRpQyt9TcHVsEumnFBagrc