### PR TITLE
Fix light mode under OS dark and force white CV PDF export

### DIFF
--- a/app/body-layout.tsx
+++ b/app/body-layout.tsx
@@ -3,15 +3,12 @@
 import { Inter } from "next/font/google";
 import Header from "@/components/header";
 import Footer from "@/components/footer";
-import { useThemeContext } from "@/context/theme";
 
 const inter = Inter({ subsets: ["latin"] });
 
 export function BodyLayout({ children }: { children: React.ReactNode }) {
-  const { theme } = useThemeContext();
-
   return (
-    <body className={`flex flex-col min-h-[100vh] container max-w-6xl print:max-w-none print:p-0 ${inter.className} ${theme}`}>
+    <body className={`flex flex-col min-h-[100vh] container max-w-6xl print:max-w-none print:p-0 ${inter.className}`}>
       <Header />
       <main className="flex-grow">{children}</main>
       <Footer />

--- a/app/globals.css
+++ b/app/globals.css
@@ -66,6 +66,21 @@
   }
 }
 
+/* Tell the browser which scheme the page is really in (the theme class lives
+   on <html>). Kept outside @layer so it always beats layered rules, e.g.
+   daisyUI's `:root { color-scheme }`. "only" opts the light theme out of
+   browser auto-darkening (Chrome's darker theme), which would otherwise
+   repaint it as just another dark mode; the plain value first is the fallback
+   for browsers without "only" support. */
+:root {
+  color-scheme: light;
+  color-scheme: only light;
+}
+
+:root.dark {
+  color-scheme: dark;
+}
+
 /* Removing the vertical scrollbar from the browsers */
 /* Safari and Chrome */
 ::-webkit-scrollbar {
@@ -95,8 +110,11 @@
     margin: 12mm;
   }
 
-  html {
-    color-scheme: light;
+  /* :root specificity so this beats any :root-level color-scheme rule
+     (e.g. from plugins); "only light" keeps the printed canvas white even
+     when the OS is in dark mode. */
+  :root, :root.dark {
+    color-scheme: only light;
   }
 
   body {
@@ -104,16 +122,24 @@
   }
 
   /* The CV always exports in light mode, whatever the on-screen theme */
-  body, body.dark {
+  :root, :root.dark {
     --background: 0 0% 100%;
     --foreground: 240 10% 3.9%;
     --card: 0 0% 100%;
     --card-foreground: 240 10% 3.9%;
+    --popover: 0 0% 100%;
+    --popover-foreground: 240 10% 3.9%;
+    --primary: 240 5.9% 10%;
+    --primary-foreground: 0 0% 98%;
     --secondary: 240 4.8% 95.9%;
     --secondary-foreground: 240 5.9% 10%;
     --muted: 240 4.8% 95.9%;
     --muted-foreground: 240 3.8% 46.1%;
+    --accent: 240 4.8% 95.9%;
+    --accent-foreground: 240 5.9% 10%;
     --border: 240 5.9% 90%;
+    --input: 240 5.9% 90%;
+    --ring: 240 10% 3.9%;
   }
 
   /* Keep the grey section banners visible on paper */

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -22,13 +22,26 @@ export const metadata: Metadata = {
   },
 };
 
+// Runs before first paint so the page never flashes the wrong theme.
+// Must mirror determineTheme() in context/theme.tsx.
+const themeInitScript = `
+try {
+  var theme = localStorage.getItem("themePreference")
+    || (window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light");
+  document.documentElement.classList.add(theme);
+} catch (e) {}
+`;
+
 export default function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
+      <head>
+        <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
+      </head>
       <ThemeContextProvider>
         <BodyLayout>{children}</BodyLayout>
       </ThemeContextProvider>

--- a/context/theme.tsx
+++ b/context/theme.tsx
@@ -15,19 +15,28 @@ const determineTheme = () => {
   return localTheme || systemTheme
 }
 
-export default function ThemeContextProvider({ children }: { children: ReactNode }) {  
+// The theme class lives on <html> so it controls CSS variables, Tailwind's
+// dark: variants and the browser color-scheme everywhere, including before
+// hydration (see the inline script in app/layout.tsx).
+const applyTheme = (choise: string) => {
+  document.documentElement.classList.remove(choise === "dark" ? "light" : "dark")
+  document.documentElement.classList.add(choise)
+}
+
+export default function ThemeContextProvider({ children }: { children: ReactNode }) {
   const [theme, setTheme] = useState<string>()
 
   useEffect(() => {
-    setTheme(determineTheme())
-  }, [])
-  
-  const handleChangeTheme = useCallback((choise: string) => {
-    setTheme(choise)
-    localStorage.setItem("themePreference", choise)
+    const initial = determineTheme()
+    setTheme(initial)
+    applyTheme(initial)
   }, [])
 
-  if (!theme && process.env.NODE_ENV != "development") return null  // TODO: Find a way to fix this monstrosity!
+  const handleChangeTheme = useCallback((choise: string) => {
+    setTheme(choise)
+    applyTheme(choise)
+    localStorage.setItem("themePreference", choise)
+  }, [])
 
   return (
     <ThemeContext.Provider value={{ theme, handleChangeTheme }}>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -84,7 +84,7 @@ const config = {
   plugins: [require("tailwindcss-animate"), require("daisyui")],
 
   daisyui: {
-    themes: false, // false: only light + dark | true: all themes | array: specific themes like this ["light", "dark", "cupcake"]
+    themes: ["light"], // only emit the light theme: keeps daisyUI from injecting `:root { color-scheme: dark }` under prefers-color-scheme, which broke light mode and PDF export on OS-dark machines (site colors come from our own CSS variables above)
     darkTheme: "dark", // name of one of the included themes for dark mode
     base: false, // applies background color and foreground color for root element by default
     styled: false, // include daisyUI colors and design decisions for all components


### PR DESCRIPTION
daisyUI was injecting `@media (prefers-color-scheme: dark) { :root {
color-scheme: dark } }`, so for visitors with a dark OS theme the page
was treated as dark regardless of the site toggle: browsers could
auto-darken the light theme into "another dark mode", and Chromium
painted a dark canvas behind the CV when printing (the print rule
`html { color-scheme: light }` lost to daisyUI's `:root` rule on
specificity).

- Limit daisyUI to its light theme so it no longer declares a dark
  scheme at :root (only structural daisy-timeline classes are used)
- Declare color-scheme explicitly per theme, unlayered so it wins:
  `only light` by default (opting out of browser auto-darkening) and
  `dark` when the dark theme is active
- Move the theme class from <body> to <html> and set it with an inline
  pre-paint script, removing the production-only `return null` in the
  theme provider that shipped an empty <body> in the static export
- Harden @media print: force `color-scheme: only light` at :root
  specificity and override the full CSS variable palette so the PDF is
  always white, whatever the on-screen theme

Verified on the static export (output: "export") with headless Chromium
in OS-dark mode: light/dark themes render correctly on screen and PDFs
from both themes now paint a white page with dark text.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012jwEyvtC4zbUcf2Zwrnzmb