### PR TITLE
Improve theme system and navigation links

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -64,6 +64,43 @@
     --input: 240 3.7% 15.9%;
     --ring: 240 4.9% 83.9%;
   }
+
+  /* Same palette as .dark, applied when the OS prefers dark and no explicit
+     theme class made it onto <html> (no JS). It also signals browsers with a
+     "force dark" feature (Samsung Internet, Chrome auto-dark) that the page
+     has a native dark theme, so they render it instead of color-inverting
+     the light one. An explicit .light choice always wins via :not(). */
+  @media (prefers-color-scheme: dark) {
+    :root:not(.light) {
+      --background: 240 10% 3.9%;
+      --foreground: 0 0% 98%;
+
+      --card: 240 10% 3.9%;
+      --card-foreground: 0 0% 98%;
+
+      --popover: 240 10% 3.9%;
+      --popover-foreground: 0 0% 98%;
+
+      --primary: 0 0% 98%;
+      --primary-foreground: 240 5.9% 10%;
+
+      --secondary: 240 3.7% 15.9%;
+      --secondary-foreground: 0 0% 98%;
+
+      --muted: 240 3.7% 15.9%;
+      --muted-foreground: 240 5% 64.9%;
+
+      --accent: 240 3.7% 15.9%;
+      --accent-foreground: 0 0% 98%;
+
+      --destructive: 0 62.8% 30.6%;
+      --destructive-foreground: 0 0% 98%;
+
+      --border: 240 3.7% 15.9%;
+      --input: 240 3.7% 15.9%;
+      --ring: 240 4.9% 83.9%;
+    }
+  }
 }
 
 /* Tell the browser which scheme the page is really in (the theme class lives
@@ -75,6 +112,14 @@
 :root {
   color-scheme: light;
   color-scheme: only light;
+}
+
+/* Mirrors the variable fallback above: correct scheme when no theme class is
+   present, and a dark-support signal for force-dark browsers. */
+@media (prefers-color-scheme: dark) {
+  :root:not(.light) {
+    color-scheme: dark;
+  }
 }
 
 :root.dark {
@@ -110,10 +155,11 @@
     margin: 12mm;
   }
 
-  /* :root specificity so this beats any :root-level color-scheme rule
-     (e.g. from plugins); "only light" keeps the printed canvas white even
-     when the OS is in dark mode. */
-  :root, :root.dark {
+  /* :root:not(.light) matches the specificity of the prefers-color-scheme
+     fallbacks above so print beats them too (later in source wins the tie);
+     "only light" keeps the printed canvas white even when the OS is in dark
+     mode. */
+  :root, :root.dark, :root:not(.light) {
     color-scheme: only light;
   }
 
@@ -122,7 +168,7 @@
   }
 
   /* The CV always exports in light mode, whatever the on-screen theme */
-  :root, :root.dark {
+  :root, :root.dark, :root:not(.light) {
     --background: 0 0% 100%;
     --foreground: 240 10% 3.9%;
     --card: 0 0% 100%;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -40,6 +40,11 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
+        {/* Declares native light+dark support so force-dark browsers
+            (e.g. Samsung Internet) honor the page's own theme instead of
+            color-inverting it. The CSS color-scheme rules in globals.css
+            still decide the actual scheme per theme class. */}
+        <meta name="color-scheme" content="light dark" />
         <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
       </head>
       <ThemeContextProvider>

--- a/components/change-theme-button.tsx
+++ b/components/change-theme-button.tsx
@@ -4,15 +4,24 @@ import { useThemeContext } from "@/context/theme";
 import { Moon, Sun } from "lucide-react";
 
 export default function ChangeThemeButton() {
-  const { theme, handleChangeTheme } = useThemeContext();
+  const { handleChangeTheme } = useThemeContext();
+
+  // Flip based on the class actually on <html> (set pre-paint by the inline
+  // script in app/layout.tsx), so the toggle is right even if React state
+  // hasn't caught up with it.
+  const toggleTheme = () =>
+    handleChangeTheme(document.documentElement.classList.contains("dark") ? "light" : "dark");
 
   return (
     <button
-      className="flex gap-4 my-auto dark:bg-zinc-800 bg-zinc-100 p-2 rounded-full transition-color duration-300"
-      onClick={() => handleChangeTheme(theme === "light" ? "dark" : "light")}
+      className="flex gap-4 my-auto dark:bg-zinc-800 bg-zinc-100 p-2 rounded-full transition-colors duration-300"
+      onClick={toggleTheme}
     >
-      <Sun className={`${theme == "dark" && "text-zinc-800"}`} size={24} />
-      <Moon className={`${theme == "light" && "text-zinc-100"}`} size={24} />
+      {/* Each icon matches the pill background of the opposite theme, so the
+          active one is visible and the other blends in — pure CSS, correct
+          even before hydration sets `theme`. */}
+      <Sun className="text-zinc-800" size={24} />
+      <Moon className="text-zinc-100" size={24} />
       <span className="sr-only">Toggle theme</span>
     </button>
   );

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -10,7 +10,7 @@ export default function Footer() {
       <div className="flex flex-col sm:flex-row justify-between gap-8 items-center text-muted-foreground">
         <ul className="sm:w-28 flex flex-col items-center gap-2 px-4">
           <li>
-            <Link className="hover:underline underline-offset-4" href="#">
+            <Link className="hover:underline underline-offset-4" href="/">
               Home
             </Link>
           </li>

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -6,18 +6,20 @@ import DesktopMenu from "./desktop-menu";
 
 export default function Header(){
 
+  // Root-relative so the anchors work from any route (e.g. /cv/en), not
+  // only from the homepage itself.
   const menuItems = [
-    { name: "About", link: "#about" },
-    { name: "Projects", link: "#projects" },
-    { name: "News", link: "#news" },
-    { name: "Contact", link: "#contact" },
+    { name: "About", link: "/#about" },
+    { name: "Projects", link: "/#projects" },
+    { name: "News", link: "/#news" },
+    { name: "Contact", link: "/#contact" },
     { name: "Blog", link: "https://igormcsouza.github.io/blog" },
   ];
 
   return (
     <header className="py-6 lg:py-10 print:hidden">
       <div className="flex gap-4 flex-row justify-between items-center md:gap-8">
-        <Link className="hidden lg:inline-block" href="#">
+        <Link className="hidden lg:inline-block" href="/">
           <LogoIcon className="dark:text-zinc-800 text-zinc-200 text-4xl" />
         </Link>
         <DesktopMenu menuItems={menuItems} />


### PR DESCRIPTION
## Summary
This PR enhances the theme system to work correctly without JavaScript and improves navigation by making links root-relative. The changes ensure the dark theme is properly applied based on OS preferences even before React hydration, and fix anchor links to work from any route.

## Key Changes

- **CSS-based theme fallback**: Added `@media (prefers-color-scheme: dark)` rules to apply dark theme variables when the OS prefers dark mode and no explicit theme class is present. This ensures correct styling before JavaScript runs and signals to force-dark browsers (Samsung Internet, Chrome) that the page has native dark theme support.

- **Color-scheme meta tag**: Added `<meta name="color-scheme" content="light dark" />` to declare native light and dark theme support, preventing force-dark browsers from color-inverting the page.

- **Theme toggle refactor**: Updated `ChangeThemeButton` to read the actual DOM class state instead of relying on React context state, ensuring the toggle works correctly even before hydration. Simplified icon styling to use pure CSS that works pre-hydration.

- **Root-relative navigation links**: Changed all internal anchor links from `#section` to `/#section` in header and footer components, allowing them to work correctly from any route (e.g., `/cv/en`).

- **Print stylesheet updates**: Updated print media query selectors to include `:root:not(.light)` to match the specificity of the new prefers-color-scheme fallbacks.

## Implementation Details

- The theme system now has three layers: explicit `.light` class (highest priority), OS preference via `prefers-color-scheme` media query, and default light theme.
- The `:not(.light)` selector ensures explicit light theme choice always wins over OS dark preference.
- Comments added throughout to explain the theme system's behavior and the reasoning behind CSS specificity choices.
- Fixed typo: `transition-color` → `transition-colors` in button styling.

https://claude.ai/code/session_01SVnK9unLdyecCsDZvJQENw