### PR TITLE
Close mobile menu when a nav link is selected

### DIFF
--- a/components/mobile-menu.tsx
+++ b/components/mobile-menu.tsx
@@ -1,6 +1,6 @@
 import { Button } from "./ui/button";
 import { Menu } from "lucide-react";
-import { Sheet, SheetContent, SheetTrigger } from "./ui/sheet";
+import { Sheet, SheetClose, SheetContent, SheetTrigger } from "./ui/sheet";
 import Link from "next/link";
 
 export default function MobileMenu({ menuItems }: { menuItems: { name: string, link: string }[] }) {
@@ -14,9 +14,11 @@ export default function MobileMenu({ menuItems }: { menuItems: { name: string, l
           <ul className="flex flex-col gap-4">
             {menuItems.map((item, index) => (
               <li key={index}>
-                <Link href={item.link}>
-                  <Button variant={"ghost"}>{item.name}</Button>
-                </Link>
+                <SheetClose asChild>
+                  <Link href={item.link}>
+                    <Button variant={"ghost"}>{item.name}</Button>
+                  </Link>
+                </SheetClose>
               </li>
             ))}
           </ul>


### PR DESCRIPTION
The mobile Sheet had no way to signal Radix to close itself when a nav
link was clicked, so the panel stayed open after navigating to a
section. Wrap each link in SheetClose (asChild), the same mechanism
already used by the sheet's explicit close button.

Fixes #53