### PR TITLE
Fix mobile navbar layout shift and section links not scrolling

### DIFF
--- a/app/body-layout.tsx
+++ b/app/body-layout.tsx
@@ -8,10 +8,12 @@ const inter = Inter({ subsets: ["latin"] });
 
 export function BodyLayout({ children }: { children: React.ReactNode }) {
   return (
-    <body className={`flex flex-col min-h-[100vh] container max-w-6xl print:max-w-none print:p-0 ${inter.className}`}>
-      <Header />
-      <main className="flex-grow">{children}</main>
-      <Footer />
+    <body className={`flex flex-col min-h-[100vh] ${inter.className}`}>
+      <div className="flex flex-col min-h-[100vh] container max-w-6xl print:max-w-none print:p-0">
+        <Header />
+        <main className="flex-grow">{children}</main>
+        <Footer />
+      </div>
     </body>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,7 @@
 import About from "@/components/about";
 import Contact from "@/components/contact";
 import GoTop from "@/components/go-top";
+import HashScroll from "@/components/hash-scroll";
 import Hero from "@/components/hero";
 import News from "@/components/news";
 import Projects from "@/components/projects";
@@ -9,6 +10,7 @@ import Resume from "@/components/resume";
 export default function Homepage() {
   return (
     <div className="flex flex-col gap-16 my-10">
+      <HashScroll />
       <Hero />
       <Resume />
       <About />

--- a/components/desktop-menu.tsx
+++ b/components/desktop-menu.tsx
@@ -1,7 +1,4 @@
-import Link from "next/link";
-import { Button } from "./ui/button";
-
-import React from 'react'
+import NavLink from "./nav-link";
 
 export default function DesktopMenu({ menuItems }: { menuItems: {name: string, link: string}[]}) {
   return (
@@ -9,9 +6,7 @@ export default function DesktopMenu({ menuItems }: { menuItems: {name: string, l
       <ul className="flex flex-wrap sm:gap-16">
         {menuItems.map((item, index) => (
           <li key={index}>
-            <Link href={item.link}>
-              <Button variant={"ghost"}>{item.name}</Button>
-            </Link>
+            <NavLink item={item} />
           </li>
         ))}
       </ul>

--- a/components/hash-scroll.tsx
+++ b/components/hash-scroll.tsx
@@ -1,0 +1,18 @@
+"use client"
+
+import { useEffect } from "react";
+import { scrollToSection } from "./scroll-to-section";
+
+// Scrolls to the section named by the URL hash on initial mount - used for
+// landing on "/#about" from another route (e.g. /cv/en), where Next's
+// built-in hash-scroll-on-load isn't reliably firing.
+export default function HashScroll() {
+  useEffect(() => {
+    const id = window.location.hash.slice(1);
+    if (id) {
+      scrollToSection(id);
+    }
+  }, []);
+
+  return null;
+}

--- a/components/mobile-menu.tsx
+++ b/components/mobile-menu.tsx
@@ -1,24 +1,43 @@
+"use client"
+
+import { useRef, useState } from "react";
 import { Button } from "./ui/button";
 import { Menu } from "lucide-react";
-import { Sheet, SheetClose, SheetContent, SheetTrigger } from "./ui/sheet";
-import Link from "next/link";
+import { Sheet, SheetContent, SheetTrigger } from "./ui/sheet";
+import NavLink from "./nav-link";
+import { scrollToSection } from "./scroll-to-section";
 
 export default function MobileMenu({ menuItems }: { menuItems: { name: string, link: string }[] }) {
+  const [open, setOpen] = useState(false);
+  const pendingScrollId = useRef<string | null>(null);
+
   return (
     <nav className="my-auto text-xl lg:hidden inline-block">
-      <Sheet>
+      <Sheet open={open} onOpenChange={setOpen}>
         <SheetTrigger asChild>
           <Button variant={"ghost"}><Menu /></Button>
         </SheetTrigger>
-        <SheetContent side="left">
+        <SheetContent
+          side="left"
+          onCloseAutoFocus={(e) => {
+            const id = pendingScrollId.current;
+            if (id) {
+              // Cancel Radix's default focus-return to the trigger button -
+              // it auto-scrolls the trigger into view and fights our scroll.
+              e.preventDefault();
+              pendingScrollId.current = null;
+              scrollToSection(id);
+            }
+          }}
+        >
           <ul className="flex flex-col gap-4">
             {menuItems.map((item, index) => (
               <li key={index}>
-                <SheetClose asChild>
-                  <Link href={item.link}>
-                    <Button variant={"ghost"}>{item.name}</Button>
-                  </Link>
-                </SheetClose>
+                <NavLink
+                  item={item}
+                  onSectionLink={(id) => { pendingScrollId.current = id; }}
+                  onClick={() => setOpen(false)}
+                />
               </li>
             ))}
           </ul>

--- a/components/nav-link.tsx
+++ b/components/nav-link.tsx
@@ -1,0 +1,54 @@
+"use client"
+
+import * as React from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { Button } from "./ui/button";
+import { scrollToSection } from "./scroll-to-section";
+
+type NavLinkProps = {
+  item: { name: string; link: string };
+  // Same-page section links normally scroll immediately, but inside the
+  // mobile Sheet, closing it returns focus to the trigger button, which
+  // auto-scrolls it back into view and fights our scroll. Callers with that
+  // constraint (mobile-menu) pass this to take over the scroll themselves,
+  // once it's safe to do so; it's also called for cross-route section links
+  // (e.g. from /cv/en) for the same reason, even though navigation isn't
+  // intercepted for those.
+  onSectionLink?: (sectionId: string) => void;
+} & Omit<React.ComponentPropsWithoutRef<typeof Link>, "href">;
+
+// For same-page section links (e.g. "/#about" while already on "/"), Link's
+// own hash navigation isn't reliable, so we scroll to the section directly
+// and skip routing. Cross-route links (e.g. from /cv/en) still navigate
+// normally, since the target section only exists on "/".
+const NavLink = React.forwardRef<HTMLAnchorElement, NavLinkProps>(
+  ({ item, onSectionLink, onClick, ...props }, ref) => {
+    const pathname = usePathname();
+
+    function handleClick(e: React.MouseEvent<HTMLAnchorElement>) {
+      if (item.link.startsWith("/#")) {
+        const id = item.link.slice(2);
+        if (pathname === "/") {
+          e.preventDefault();
+          onSectionLink ? onSectionLink(id) : scrollToSection(id);
+        } else {
+          // Cross-route: let Link navigate; the destination page scrolls
+          // to the section once it mounts (see hash-scroll.tsx), unless a
+          // caller wants to coordinate that itself (see onSectionLink doc).
+          onSectionLink?.(id);
+        }
+      }
+      onClick?.(e);
+    }
+
+    return (
+      <Link ref={ref} href={item.link} onClick={handleClick} {...props}>
+        <Button variant={"ghost"}>{item.name}</Button>
+      </Link>
+    );
+  }
+);
+NavLink.displayName = "NavLink";
+
+export default NavLink;

--- a/components/scroll-to-section.ts
+++ b/components/scroll-to-section.ts
@@ -1,0 +1,24 @@
+// The mobile Sheet locks body scroll (sets a `data-scroll-locked` attribute,
+// via react-remove-scroll under the hood) until its close animation
+// finishes, so a scrollIntoView issued while it's still closing is a no-op.
+// This waits for the lock to actually clear - across route transitions too,
+// since the Sheet lives in the shared root layout - before scrolling.
+export function scrollToSection(id: string) {
+  const el = document.getElementById(id);
+  if (!el) return;
+
+  if (!document.body.hasAttribute("data-scroll-locked")) {
+    el.scrollIntoView({ behavior: "smooth" });
+    return;
+  }
+
+  const observer = new MutationObserver(() => {
+    if (!document.body.hasAttribute("data-scroll-locked")) {
+      observer.disconnect();
+      el.scrollIntoView({ behavior: "smooth" });
+    }
+  });
+  observer.observe(document.body, { attributes: true, attributeFilter: ["data-scroll-locked"] });
+  // Safety net in case the attribute never clears.
+  setTimeout(() => observer.disconnect(), 1000);
+}


### PR DESCRIPTION
## Summary

Follow-up to #53. The original sheet-close fix (`SheetClose`) had already been merged separately as #75, but on the now-current `main` (Next.js 16, rebuilt after a large dependency bump) two related mobile navbar problems remained:

- **Content shifts when the menu opens.** Tailwind's `container` centering classes were applied directly to `<body>` in `app/body-layout.tsx`, which Radix's scroll-lock styles (also targeting `<body>` while the Sheet is open) fought with — causing a visible horizontal jump. Fixed by moving the container classes to an inner wrapper `<div>`.
- **Section nav links "reload" back to the top instead of scrolling to the section.** This was three compounding issues: `next/link`'s implicit same-page hash scrolling isn't reliable here; the mobile Sheet keeps the background scroll-locked until its close animation finishes, silently no-oping any scroll issued immediately on click; and Radix's default focus-return-to-trigger behavior after closing was auto-scrolling the hamburger button back into view, canceling the section scroll. Fixed with a shared `scrollToSection` helper (`components/scroll-to-section.ts`) that waits out the scroll lock, a new `NavLink` component (`components/nav-link.tsx`) shared by the desktop and mobile menus that scrolls directly for same-page section links, and a `HashScroll` component (`components/hash-scroll.tsx`) that handles landing on `/#section` from another route (e.g. `/cv/en`).

The branch was also restarted from current `main` before this work, since the branch's earlier commit duplicated the already-merged #75.

## Test plan

- [x] `npm run lint` and `npm run build` pass
- [x] Verified with Playwright at a mobile viewport (390×844): opening the sheet causes no layout shift; clicking a section link (About/Contact) closes the sheet, scrolls to the section, and does not trigger a full page navigation
- [x] Verified cross-route navigation (from `/cv/en`, clicking a section link) performs a real navigation to `/` and lands scrolled to the correct section
- [x] Verified at a desktop viewport (1280×900) for both same-page and cross-route cases
- [x] Verified Escape-key close (no nav link clicked) and the external "Blog" link still behave normally, with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_017Bxjyzfwi5CEibfnZ4BmNR)_